### PR TITLE
migrating to CryptSharpOfficial-2.0.0

### DIFF
--- a/src/Malt.PasswordHasher/packages.config
+++ b/src/Malt.PasswordHasher/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CryptSharp" version="1.2.0.1" targetFramework="net451" />
+  <package id="CryptSharpOfficial" version="2.0.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Identity.Core" version="1.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
CryptSharp is now maintained by the package CryptSharpOfficial
